### PR TITLE
pytest-astropy 0.11.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,7 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/cd842ea
+  - https://staging.continuum.io/prefect/fs/pytest-astropy-header-feedstock/pr3/0abff91
+  - https://staging.continuum.io/prefect/fs/pytest-doctestplus-feedstock/pr8/695fc0b
+  - https://staging.continuum.io/prefect/fs/pytest-filter-subpackage-feedstock/pr1/85e8265
+  - https://staging.continuum.io/prefect/fs/pytest-remotedata-feedstock/pr2/a56c162

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/5462b14

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/5462b14
+  - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/cd842ea

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/pytest-arraydiff-feedstock/pr3/cd842ea
-  - https://staging.continuum.io/prefect/fs/pytest-astropy-header-feedstock/pr3/0abff91
-  - https://staging.continuum.io/prefect/fs/pytest-doctestplus-feedstock/pr8/695fc0b
-  - https://staging.continuum.io/prefect/fs/pytest-filter-subpackage-feedstock/pr1/85e8265
-  - https://staging.continuum.io/prefect/fs/pytest-remotedata-feedstock/pr2/a56c162

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ test:
     - pip check || exit 0  # [win]
 
 about:
-  home: {{ git_url }}
+  home: https://github.com/astropy/pytest-astropy
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.rst
@@ -58,8 +58,8 @@ about:
     This is a meta-package that pulls in the dependencies that are used by
     astropy and some affiliated packages for testing. It can also be used for
     testing packages that are not affiliated with the Astropy project.
-  doc_url: {{ git_url }}
-  dev_url: {{ git_url }}
+  doc_url: https://github.com/astropy/pytest-astropy
+  dev_url: https://github.com/astropy/pytest-astropy
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,8 @@ requirements:
     - pytest-mock >=2.0
     - attrs >=19.2.0
     - hypothesis >=5.1
+  run_constrained:
+    - pytest-mpl >=0.11
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,24 +14,23 @@ source:
 build:
   skip: True  # [py<37]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
-    - setuptools >=30.3.0
+    - setuptools
     - setuptools_scm
     - wheel
   run:
     - python
     - pytest >=4.6
-    - pytest-doctestplus >=0.11.0
-    - pytest-remotedata >=0.3.1
-    - pytest-openfiles >=0.3.1
-    - pytest-astropy-header >=0.1.2
-    - pytest-arraydiff >=0.1
-    - pytest-filter-subpackage >=0.1
+    - pytest-doctestplus >=1.0.0
+    - pytest-remotedata >=0.4.1
+    - pytest-astropy-header >=0.2.2
+    - pytest-arraydiff >=0.5
+    - pytest-filter-subpackage >=0.1.2
     - pytest-cov >=2.3.1
     - pytest-mock >=2.0
     - attrs >=19.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "pytest-astropy" %}
-{% set version = "0.10.0" %}
-{% set git_url = "https://github.com/astropy/pytest-astropy" %}
-{% set sha256 = "85e3c66ceede4ce668f473b3cf377fcb2aa3c48e24f28aaa377ae86004cce211" %}
+{% set version = "0.11.0" %}
+{% set sha256 = "4eaeaa99ed91163ed8f9aac132c70a81f25bc4c12f3cd54dba329fc26c6739b5" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,15 +38,11 @@ requirements:
 
 test:
   imports:
-    - pytest_remotedata
-    - pytest_doctestplus
-    - pytest_openfiles
-    - pytest_arraydiff
+    - pytest_astropy
   requires:
     - pip
   commands:
-    - pip check || true    # [not win]
-    - pip check || exit 0  # [win]
+    - pip check
 
 about:
   home: https://github.com/astropy/pytest-astropy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pytest-astropy" %}
-{% set version = "0.10.0" %}
-{% set sha256 = "85e3c66ceede4ce668f473b3cf377fcb2aa3c48e24f28aaa377ae86004cce211" %}
+{% set version = "0.11.0" %}
+{% set sha256 = "4eaeaa99ed91163ed8f9aac132c70a81f25bc4c12f3cd54dba329fc26c6739b5" %}
 
 package:
   name: {{ name|lower }}
@@ -26,12 +26,11 @@ requirements:
   run:
     - python
     - pytest >=4.6
-    - pytest-doctestplus >=0.11.0
-    - pytest-remotedata >=0.3.1
-    - pytest-openfiles >=0.3.1
-    - pytest-astropy-header >=0.1.2
-    - pytest-arraydiff >=0.1
-    - pytest-filter-subpackage >=0.1
+    - pytest-doctestplus >=1.0.0
+    - pytest-remotedata >=0.4.1
+    - pytest-astropy-header >=0.2.2
+    - pytest-arraydiff >=0.5
+    - pytest-filter-subpackage >=0.1.2
     - pytest-cov >=2.3.1
     - pytest-mock >=2.0
     - attrs >=19.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pytest-astropy" %}
-{% set version = "0.11.0" %}
-{% set sha256 = "4eaeaa99ed91163ed8f9aac132c70a81f25bc4c12f3cd54dba329fc26c6739b5" %}
+{% set version = "0.10.0" %}
+{% set sha256 = "85e3c66ceede4ce668f473b3cf377fcb2aa3c48e24f28aaa377ae86004cce211" %}
 
 package:
   name: {{ name|lower }}
@@ -14,23 +14,24 @@ source:
 build:
   skip: True  # [py<37]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install . --no-deps  --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=30.3.0
     - setuptools_scm
     - wheel
   run:
     - python
     - pytest >=4.6
-    - pytest-doctestplus >=1.0.0
-    - pytest-remotedata >=0.4.1
-    - pytest-astropy-header >=0.2.2
-    - pytest-arraydiff >=0.5
-    - pytest-filter-subpackage >=0.1.2
+    - pytest-doctestplus >=0.11.0
+    - pytest-remotedata >=0.3.1
+    - pytest-openfiles >=0.3.1
+    - pytest-astropy-header >=0.1.2
+    - pytest-arraydiff >=0.1
+    - pytest-filter-subpackage >=0.1
     - pytest-cov >=2.3.1
     - pytest-mock >=2.0
     - attrs >=19.2.0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6874](https://anaconda.atlassian.net/browse/PKG-6874)
- [Upstream repository](https://github.com/astropy/pytest-astropy/tree/v0.11.0)
- [Upstream changelog/diff](https://github.com/astropy/pytest-astropy/compare/v0.10.0...v0.11.0)
- Relevant dependency PRs:
  - dependency for `astropy`

### Explanation of changes:

- Update version and sha
- Build for python 3.13
- Update dependencies
- Linter fixes


[PKG-6874]: https://anaconda.atlassian.net/browse/PKG-6874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ